### PR TITLE
Define a trait and use dynamic dispatch for different TTS engines/providers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 )]
 
 use std::{
+    collections::HashMap,
     fmt::Display,
     str::FromStr,
     sync::{
@@ -18,6 +19,7 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
+use async_trait::async_trait;
 use axum::{
     Json,
     http::header::HeaderValue,
@@ -45,12 +47,6 @@ use modes::{espeak, gcloud, gtts, polly};
 type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 type ResponseResult<T> = std::result::Result<T, Error>;
 type AudioCacheDigest = GenericArray<u8, U32>;
-
-#[must_use]
-pub fn check_mp3_length(audio: &[u8], max_length: u64) -> bool {
-    use bytes::Buf;
-    mp3_duration::from_read(&mut audio.reader()).map_or(true, |d| d.as_secs() < max_length)
-}
 
 pub struct DeadlineMonitor<F: FnOnce(Duration)> {
     start: Instant,
@@ -100,15 +96,15 @@ async fn get_voices(
         match mode {
             TTSMode::gTTS => to_value(gtts::get_raw_voices()),
             TTSMode::eSpeak => to_value(espeak::get_voices()),
-            TTSMode::Polly => to_value(polly::get_raw_voices(&state.polly).await?),
-            TTSMode::gCloud => to_value(gcloud::get_raw_voices(&state.gcloud).await?),
+            TTSMode::Polly => to_value(polly::get_raw_voices(state.polly.as_ref()?).await?),
+            TTSMode::gCloud => to_value(gcloud::get_raw_voices(&state.gcloud?).await?),
         }?
     } else {
         to_value(match mode {
             TTSMode::gTTS => gtts::get_voices(),
             TTSMode::eSpeak => espeak::get_voices().to_vec(),
-            TTSMode::Polly => polly::get_voices(&state.polly).await?,
-            TTSMode::gCloud => gcloud::get_voices(&state.gcloud).await?,
+            TTSMode::Polly => polly::get_voices(&state.polly?).await?,
+            TTSMode::gCloud => gcloud::get_voices(&state.gcloud?).await?,
         })?
     }))
 }
@@ -285,7 +281,7 @@ async fn get_tts_inner(
 
     let (audio, content_type) = match query.mode {
         TTSMode::gTTS => {
-            gtts::get_tts(&state.gtts, &text, &query.voice, hit_any_deadline.clone()).await?
+            gtts::get_tts(&state.gtts?, &text, &query.voice, hit_any_deadline.clone()).await?
         }
         TTSMode::eSpeak => {
             espeak::get_tts(
@@ -297,7 +293,7 @@ async fn get_tts_inner(
         }
         TTSMode::Polly => {
             polly::get_tts(
-                &state.polly,
+                &state.polly?,
                 text,
                 &query.voice,
                 query.speaking_rate.map(|r| r as u8),
@@ -307,7 +303,7 @@ async fn get_tts_inner(
         }
         TTSMode::gCloud => {
             gcloud::get_tts(
-                &state.gcloud,
+                &state.gcloud?,
                 &text,
                 &query.voice,
                 query.speaking_rate.unwrap_or(0.0),
@@ -343,6 +339,30 @@ enum TTSMode {
     eSpeak,
     gCloud,
 }
+struct TTSVoices {
+    raw: serde_json::Value,
+    nice: Vec<String>,
+}
+#[derive(Debug, Clone, Copy)]
+struct TTSParams<'a> {
+    voice: &'a str,
+    lang: &'a str,
+    speaking_rate: f32,
+}
+
+#[async_trait]
+trait TTSEngine {
+    async fn check_params(&self, params: TTSParams<'_>) -> Option<Response>;
+    fn check_length(&self, audio: &[u8], max_length: u64) -> bool;
+    async fn speak(
+        &self,
+        text: &str,
+        params: TTSParams<'_>,
+        preferred_format: Option<&str>,
+    ) -> Result<(Bytes, Option<HeaderValue>)>;
+    async fn get_voices(&self) -> Result<TTSVoices>;
+    fn get_defaults(&self) -> TTSParams<'static>;
+}
 
 impl TTSMode {
     fn into_response(
@@ -370,7 +390,7 @@ impl TTSMode {
         if match self {
             Self::gTTS => gtts::check_voice(voice),
             Self::eSpeak => espeak::check_voice(voice),
-            Self::gCloud => gcloud::check_voice(&state.gcloud, voice).await?,
+            Self::gCloud => gcloud::check_voice(state.gcloud.as_ref()?, voice).await?,
             Self::Polly => polly::check_voice(&state.polly, voice).await?,
         } {
             Ok(())
@@ -452,9 +472,10 @@ struct State {
     cache: ArcSwap<AudioCache>,
     calls: Mutex<Option<dispatch::CallMap>>,
 
-    polly: polly::State,
-    gtts: tokio::sync::RwLock<gtts::State>,
-    gcloud: tokio::sync::RwLock<gcloud::State>,
+    engines: HashMap<String, Arc<dyn TTSEngine>>,
+    polly: Result<polly::State, Error>,
+    gtts: Result<tokio::sync::RwLock<gtts::State>, Error>,
+    gcloud: Result<tokio::sync::RwLock<gcloud::State>, Error>,
 }
 
 static STATE: OnceLock<State> = OnceLock::new();
@@ -488,10 +509,12 @@ async fn main() -> Result<()> {
     let client = reqwest::Client::new();
     let result = STATE.set(State {
         reqwest: client.clone(),
-        gcloud: gcloud::State::new(client)?,
-        polly: polly::State::new(&aws_config::load_from_env().await),
-        gtts: tokio::sync::RwLock::new(gtts::get_random_ipv6(ip_block).await?),
-
+        gcloud: gcloud::State::new(client).map_err(|e| e.into()),
+        polly: Ok(polly::State::new(&aws_config::load_from_env().await)),
+        gtts: gtts::get_random_ipv6(ip_block)
+            .await
+            .map(|v6| tokio::sync::RwLock::new(v6))
+            .map_err(|e| e.into()),
         calls: Mutex::new(Some(dispatch::CallMap::new())),
 
         cache: {
@@ -557,10 +580,9 @@ enum Error {
 
     Unknown(anyhow::Error),
 }
-
-impl<E: Into<anyhow::Error>> From<E> for Error {
-    fn from(e: E) -> Self {
-        Self::Unknown(e.into())
+impl From<anyhow::Error> for Error {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Unknown(value)
     }
 }
 
@@ -578,6 +600,7 @@ impl std::fmt::Display for Error {
         }
     }
 }
+impl std::error::Error for Error {}
 
 impl axum::response::IntoResponse for Error {
     fn into_response(self) -> Response {

--- a/src/modes/espeak.rs
+++ b/src/modes/espeak.rs
@@ -1,14 +1,19 @@
 use std::sync::{LazyLock, OnceLock};
 
 use aformat::{CapStr, ToArrayString, aformat, astr};
+use async_trait::async_trait;
+use axum::response::{IntoResponse, Response};
+use bytes::Bytes;
 use itertools::Itertools as _;
 use memchr::memmem::Finder;
 use reqwest::header::HeaderValue;
+use serde_json::to_value;
 
-use crate::Result;
+use crate::{ResponseResult, Result, TTSEngine, TTSParams, TTSVoices};
 
 const ESPEAK_NG_DATA_PATH: &str = "/usr/local/share/espeak-ng-data";
 const MBROLA_DATA_PATH: &str = "/usr/share/mbrola/data";
+const MAX_ESPEAK_RATE: f32 = 400.;
 
 struct Finders {
     replaced_with_err: Finder<'static>,
@@ -20,134 +25,159 @@ static MBROLA_ERR_FINDERS: LazyLock<Finders> = LazyLock::new(|| Finders {
     repeat_err: Finder::new(b"mbrowrap error: unable to get .wav header from mbrola"),
 });
 
-pub async fn get_tts(
-    text: &str,
-    voice: &str,
-    speaking_rate: u16,
-) -> Result<(bytes::Bytes, Option<HeaderValue>)> {
-    if !check_voice(voice) {
-        anyhow::bail!("Invalid voice: {voice}");
+struct ESpeak;
+
+#[async_trait]
+impl TTSEngine for ESpeak {
+    async fn check_params(&self, params: TTSParams<'_>) -> Option<Response> {
+        if params.speaking_rate > MAX_ESPEAK_RATE {
+            Some(format!("Speaking rate faster than max of {MAX_ESPEAK_RATE}").into_response())
+        } else if params.speaking_rate < 0. {
+            Some("Speaking rate cannot be negative".into_response())
+        } else if !self
+            .get_voices()
+            .await
+            .unwrap()
+            .nice
+            .iter()
+            .any(|s| s.as_str() == params.voice)
+        {
+            Some(format!("Voice {} is not known", params.voice).into_response())
+        } else {
+            None
+        }
     }
 
-    let voice = CapStr::<8>(voice);
-    let Finders {
-        repeat_err,
-        replaced_with_err,
-    } = &*MBROLA_ERR_FINDERS;
-
-    // We have to loop due to random "unable to get .wav header" errors.
-    let mut i = 1;
-    let mut raw_wav = loop {
-        let mut espeak_process = tokio::process::Command::new("espeak-ng")
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .args([
-                "--pho",
-                "-s",
-                &speaking_rate.to_arraystring(),
-                "-v",
-                &aformat!("mb/mb-{voice}"),
-                text,
-            ])
-            .spawn()?;
-
-        let espeak_stdout: std::process::Stdio = espeak_process
-            .stdout
-            .take()
-            .expect("Failed to open espeak stdout")
-            .try_into()?;
-
-        let mbrola_process = tokio::process::Command::new("mbrola")
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .stdin(espeak_stdout)
-            .args([
-                "-e",
-                &aformat!("{}/{voice}/{voice}", astr!(MBROLA_DATA_PATH)),
-                "-",
-                "-.wav",
-            ])
-            .spawn()?;
-
-        let (espeak_output, mbrola_output) = tokio::try_join!(
-            espeak_process.wait_with_output(),
-            mbrola_process.wait_with_output(),
-        )?;
-
-        if repeat_err.find(&espeak_output.stderr).is_some() {
-            i += 1;
-            continue;
+    fn get_defaults(&self) -> TTSParams<'static> {
+        TTSParams {
+            voice: "",
+            lang: "",
+            speaking_rate: 1.,
         }
+    }
 
-        tracing::debug!("Generated eSpeak after {i} tries");
-        if !espeak_output.stderr.is_empty() {
-            let stderr_string = String::from_utf8_lossy(&espeak_output.stderr);
-            tracing::error!("eSpeak Error: {stderr_string}");
-        }
-
-        if !mbrola_output.stderr.is_empty() {
-            let stderr_string = String::from_utf8_lossy(&mbrola_output.stderr);
-            let stderr_string = stderr_string
-                .lines()
-                .filter(|line| replaced_with_err.find(line.as_bytes()).is_none())
-                .join("\n");
-
-            tracing::error!("Mbrola Error: {stderr_string}");
-        }
-
-        break mbrola_output.stdout;
-    };
-
-    // Fix the wav header to set the ChunkSize and SubChunk2Size
-    // See:
-    // - https://github.com/hadware/voxpopuli/blob/fb94a6130c046bb9f7a27aaaed2a4b434666faa9/voxpopuli/main.py#L150-L158
-    // - http://soundfile.sapp.org/doc/WaveFormat/
-    let wav_len: u32 = raw_wav.len().try_into().expect("WAV data too long!");
-
-    raw_wav[4..8].copy_from_slice(&(wav_len - 8).to_le_bytes());
-    raw_wav[40..44].copy_from_slice(&(wav_len - 44).to_le_bytes());
-
-    Ok((
-        bytes::Bytes::from(raw_wav),
-        Some(HeaderValue::from_static("audio/wav")),
-    ))
-}
-
-pub fn check_length(audio: &[u8], max_length: u32) -> bool {
-    audio.len() as u32
-        / (u16::from_le_bytes(audio[22..24].try_into().unwrap()) as u32 * // Sample Rate
+    fn check_length(&self, audio: &[u8], max_length: u64) -> bool {
+        audio.len() as u32
+            / (u16::from_le_bytes(audio[22..24].try_into().unwrap()) as u32 * // Sample Rate
         u32::from_le_bytes(audio[24..28].try_into().unwrap()) *        // Number of Channels
         u16::from_le_bytes(audio[34..36].try_into().unwrap()) as u32   // Bits per Sample
-        / 8)
-        < max_length
-}
+        / 8) < max_length as u32
+    }
+    async fn speak(
+        &self,
+        text: &str,
+        params: TTSParams<'_>,
+        preferred_format: Option<&str>,
+    ) -> Result<(Bytes, Option<HeaderValue>)> {
+        let voice = CapStr::<8>(params.voice);
+        let Finders {
+            repeat_err,
+            replaced_with_err,
+        } = &*MBROLA_ERR_FINDERS;
 
-pub fn get_voices() -> &'static [String] {
-    static VOICES: OnceLock<Vec<String>> = OnceLock::new();
-    VOICES.get_or_init(|| {
-        (|| {
-            let mut files = Vec::new();
-            for file in std::fs::read_dir(aformat!("{}/voices/mb", astr!(ESPEAK_NG_DATA_PATH)))? {
-                let file = file?;
-                if file.file_type()?.is_file() {
-                    let file_name = file.file_name().into_string().expect("Invalid filename!");
-                    let mut file_name_iter = file_name.split('-').skip(1);
+        // We have to loop due to random "unable to get .wav header" errors.
+        let mut i = 1;
+        let mut raw_wav = loop {
+            let mut espeak_process = tokio::process::Command::new("espeak-ng")
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .args([
+                    "--pho",
+                    "-s",
+                    &params.speaking_rate.to_arraystring(),
+                    "-v",
+                    &aformat!("mb/mb-{voice}"),
+                    text,
+                ])
+                .spawn()?;
 
-                    if let Some(language) = file_name_iter.next()
-                        && file_name_iter.next().is_none()
-                    {
-                        files.push(language.to_owned());
-                    }
-                }
+            let espeak_stdout: std::process::Stdio = espeak_process
+                .stdout
+                .take()
+                .expect("Failed to open espeak stdout")
+                .try_into()?;
+
+            let mbrola_process = tokio::process::Command::new("mbrola")
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .stdin(espeak_stdout)
+                .args([
+                    "-e",
+                    &aformat!("{}/{voice}/{voice}", astr!(MBROLA_DATA_PATH)),
+                    "-",
+                    "-.wav",
+                ])
+                .spawn()?;
+
+            let (espeak_output, mbrola_output) = tokio::try_join!(
+                espeak_process.wait_with_output(),
+                mbrola_process.wait_with_output(),
+            )?;
+
+            if repeat_err.find(&espeak_output.stderr).is_some() {
+                i += 1;
+                continue;
             }
 
-            files.sort();
-            anyhow::Ok(files)
-        })()
-        .unwrap()
-    })
-}
+            tracing::debug!("Generated eSpeak after {i} tries");
+            if !espeak_output.stderr.is_empty() {
+                let stderr_string = String::from_utf8_lossy(&espeak_output.stderr);
+                tracing::error!("eSpeak Error: {stderr_string}");
+            }
 
-pub fn check_voice(voice: &str) -> bool {
-    get_voices().iter().any(|s| s.as_str() == voice)
+            if !mbrola_output.stderr.is_empty() {
+                let stderr_string = String::from_utf8_lossy(&mbrola_output.stderr);
+                let stderr_string = stderr_string
+                    .lines()
+                    .filter(|line| replaced_with_err.find(line.as_bytes()).is_none())
+                    .join("\n");
+
+                tracing::error!("Mbrola Error: {stderr_string}");
+            }
+
+            break mbrola_output.stdout;
+        };
+
+        // Fix the wav header to set the ChunkSize and SubChunk2Size
+        // See:
+        // - https://github.com/hadware/voxpopuli/blob/fb94a6130c046bb9f7a27aaaed2a4b434666faa9/voxpopuli/main.py#L150-L158
+        // - http://soundfile.sapp.org/doc/WaveFormat/
+        let wav_len: u32 = raw_wav.len().try_into().expect("WAV data too long!");
+
+        raw_wav[4..8].copy_from_slice(&(wav_len - 8).to_le_bytes());
+        raw_wav[40..44].copy_from_slice(&(wav_len - 44).to_le_bytes());
+
+        Ok((bytes::Bytes::from(raw_wav), None))
+    }
+
+    async fn get_voices(&self) -> Result<TTSVoices> {
+        static VOICES: OnceLock<Vec<String>> = OnceLock::new();
+        let voices = VOICES.get_or_init(|| {
+            (|| {
+                let mut files = Vec::new();
+                for file in std::fs::read_dir(aformat!("{}/voices/mb", astr!(ESPEAK_NG_DATA_PATH)))?
+                {
+                    let file = file?;
+                    if file.file_type()?.is_file() {
+                        let file_name = file.file_name().into_string().expect("Invalid filename!");
+                        let mut file_name_iter = file_name.split('-').skip(1);
+
+                        if let Some(language) = file_name_iter.next()
+                            && file_name_iter.next().is_none()
+                        {
+                            files.push(language.to_owned());
+                        }
+                    }
+                }
+
+                files.sort();
+                anyhow::Ok(files)
+            })()
+            .unwrap()
+        });
+        Ok(TTSVoices {
+            raw: to_value(voices).unwrap(),
+            nice: voices.clone(),
+        })
+    }
 }

--- a/src/modes/gcloud.rs
+++ b/src/modes/gcloud.rs
@@ -1,36 +1,181 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::{
+    http::HeaderValue,
+    response::{IntoResponse, Response},
+};
 use base64::Engine;
+use bytes::Bytes;
+use serde_json::to_value;
 use tokio::sync::RwLock;
 
-use crate::Result;
+use crate::{Result, TTSEngine, TTSParams, TTSVoices};
 
 const GOOGLE_API_BASE: &str = "https://texttospeech.googleapis.com/";
+const MAX_GCLOUD_RATE: f32 = 4.0;
+static VOICES: tokio::sync::OnceCell<Vec<GoogleVoice>> = tokio::sync::OnceCell::const_new();
 
 #[derive(Clone)]
 pub struct State {
     service_account: ServiceAccount,
-    expire_time: std::time::SystemTime,
     reqwest: reqwest::Client,
-    jwt_token: String,
+    jwt_token: Arc<RwLock<JWTToken>>,
+}
+#[derive(Debug, Clone)]
+struct JWTToken {
+    token: String,
+    expire_time: std::time::SystemTime,
+}
+impl JWTToken {
+    fn has_expired(&self) -> bool {
+        let current_time = std::time::SystemTime::now();
+        current_time > self.expire_time
+    }
 }
 
 impl State {
-    pub(crate) fn new(reqwest: reqwest::Client) -> Result<RwLock<Self>> {
+    pub(crate) fn new(reqwest: reqwest::Client) -> Result<Self> {
         let service_account: ServiceAccount = serde_json::from_str(&std::fs::read_to_string(
-            std::env::var("GOOGLE_APPLICATION_CREDENTIALS").unwrap(),
+            std::env::var("GOOGLE_APPLICATION_CREDENTIALS")?,
         )?)?;
 
-        let (jwt_token, expire_time) = generate_jwt(
-            service_account.private_key.clone(),
+        let jwt_token = generate_jwt(
+            &service_account.private_key,
             &service_account.client_email,
             std::time::SystemTime::now(),
         )?;
 
-        Ok(RwLock::new(Self {
+        Ok(Self {
             service_account,
-            expire_time,
             reqwest,
-            jwt_token,
-        }))
+            jwt_token: Arc::new(RwLock::new(jwt_token)),
+        })
+    }
+    async fn get_voices_(&self) -> Result<Vec<GoogleVoice>> {
+        #[derive(serde::Deserialize)]
+        struct VoiceResponse {
+            voices: Vec<GoogleVoice>,
+        }
+
+        let jwt_token = self.refresh_jwt().await?;
+        let reqwest = self.reqwest.clone();
+
+        let resp: VoiceResponse = reqwest
+            .get(format!("{GOOGLE_API_BASE}v1/voices"))
+            .header("Authorization", format!("Bearer {jwt_token}"))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        Ok(resp.voices)
+    }
+
+    async fn refresh_jwt(&self) -> Result<String> {
+        let current_time = std::time::SystemTime::now();
+        if self.jwt_token.read().await.has_expired() {
+            let mut write = self.jwt_token.write().await;
+            *write = generate_jwt(
+                &self.service_account.private_key,
+                &self.service_account.client_email,
+                current_time,
+            )?;
+        }
+        Ok(self.jwt_token.read().await.token.clone())
+    }
+}
+
+#[async_trait]
+impl TTSEngine for State {
+    async fn check_params(&self, params: TTSParams<'_>) -> Option<Response> {
+        if params.speaking_rate > MAX_GCLOUD_RATE {
+            Some(format!("Speaking rate faster than max of {MAX_GCLOUD_RATE}").into_response())
+        } else if params.speaking_rate < 0. {
+            Some("Speaking rate cannot be negative".into_response())
+        } else if !self
+            .get_voices()
+            .await
+            .ok()?
+            .nice
+            .iter()
+            .any(|s| s.as_str() == params.voice)
+        {
+            Some(format!("Voice {} is not known", params.voice).into_response())
+        } else {
+            None
+        }
+    }
+    fn check_length(&self, audio: &[u8], max_length: u64) -> bool {
+        true
+    }
+    async fn speak(
+        &self,
+        text: &str,
+        params: TTSParams<'_>,
+        preferred_format: Option<&str>,
+    ) -> Result<(Bytes, Option<HeaderValue>)> {
+        let jwt_token = self.refresh_jwt().await?;
+        let reqwest = self.reqwest.clone();
+
+        let audio_encoding = preferred_format
+            .and_then(|pf| AudioEncoding::from_str(&pf.to_uppercase()))
+            .unwrap_or(AudioEncoding::OGG_OPUS);
+
+        let resp = reqwest
+            .post(format!("{GOOGLE_API_BASE}v1/text:synthesize"))
+            .json(&generate_google_json(
+                text,
+                params.lang,
+                params.speaking_rate,
+                audio_encoding.as_str(),
+            )?)
+            .header(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {jwt_token}"),
+            )
+            .send()
+            .await?
+            .error_for_status()?;
+
+        let resp_raw = resp.bytes().await?;
+        let audio_response: AudioResponse = serde_json::from_slice(&resp_raw)?;
+
+        Ok((
+            bytes::Bytes::from(
+                base64::engine::general_purpose::STANDARD.decode(audio_response.audio_content)?,
+            ),
+            Some(reqwest::header::HeaderValue::from_static(
+                audio_encoding.content_type(),
+            )),
+        ))
+    }
+    async fn get_voices(&self) -> Result<TTSVoices> {
+        let raw_voices = VOICES.get_or_try_init(|| self.get_voices_()).await?;
+        Ok(TTSVoices {
+            raw: to_value(raw_voices)?,
+            nice: raw_voices
+                .iter()
+                .filter_map(|gvoice| {
+                    gvoice
+                        .name
+                        .splitn(3, '-')
+                        .nth(2)?
+                        .split_once('-')
+                        .filter(|(mode, _)| *mode == "Standard")
+                        .map(|(_, variant)| {
+                            let [mut language] = gvoice.languageCodes.clone();
+                            language.push(' ');
+                            language.push_str(variant);
+                            language
+                        })
+                })
+                .collect(),
+        })
+    }
+    fn get_defaults(&self) -> TTSParams<'static> {
+        todo!()
     }
 }
 
@@ -133,14 +278,14 @@ fn generate_google_json(
 }
 
 fn generate_jwt(
-    private_key_raw: String,
+    private_key_raw: &str,
     client_email: &str,
     current_time: std::time::SystemTime,
-) -> Result<(String, std::time::SystemTime)> {
+) -> Result<JWTToken> {
     let private_key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key_raw.as_bytes())?;
 
     let mut headers = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
-    headers.kid = Some(private_key_raw);
+    headers.kid = Some(private_key_raw.to_string());
 
     let new_expire_time = current_time + std::time::Duration::from_hours(1);
     let payload = serde_json::json!({
@@ -152,129 +297,8 @@ fn generate_jwt(
     });
 
     let jwt_token = jsonwebtoken::encode(&headers, &payload, &private_key)?;
-    Ok((jwt_token, new_expire_time))
-}
-
-async fn refresh_jwt(state: &RwLock<State>) -> Result<String> {
-    let current_time = std::time::SystemTime::now();
-    let (expire_time, current_jwt_token, service_account) = {
-        let state = state.read().await;
-        (
-            state.expire_time,
-            state.jwt_token.clone(),
-            state.service_account.clone(),
-        )
-    };
-
-    if current_time > expire_time {
-        let (jwt_token, new_expire_time) = generate_jwt(
-            service_account.private_key.clone(),
-            &service_account.client_email,
-            current_time,
-        )?;
-
-        let mut state = state.write().await;
-
-        state.jwt_token.clone_from(&jwt_token);
-        state.expire_time = new_expire_time;
-
-        Ok(jwt_token)
-    } else {
-        Ok(current_jwt_token)
-    }
-}
-
-pub async fn get_tts(
-    state: &RwLock<State>,
-    text: &str,
-    lang: &str,
-    speaking_rate: f32,
-    preferred_format: Option<&str>,
-) -> Result<(bytes::Bytes, Option<reqwest::header::HeaderValue>)> {
-    let jwt_token = refresh_jwt(state).await?;
-    let reqwest = state.read().await.reqwest.clone();
-
-    let audio_encoding = preferred_format
-        .and_then(|pf| AudioEncoding::from_str(&pf.to_uppercase()))
-        .unwrap_or(AudioEncoding::OGG_OPUS);
-
-    let resp = reqwest
-        .post(format!("{GOOGLE_API_BASE}v1/text:synthesize"))
-        .json(&generate_google_json(
-            text,
-            lang,
-            speaking_rate,
-            audio_encoding.as_str(),
-        )?)
-        .header(
-            reqwest::header::AUTHORIZATION,
-            format!("Bearer {jwt_token}"),
-        )
-        .send()
-        .await?
-        .error_for_status()?;
-
-    let resp_raw = resp.bytes().await?;
-    let audio_response: AudioResponse = serde_json::from_slice(&resp_raw)?;
-
-    Ok((
-        bytes::Bytes::from(
-            base64::engine::general_purpose::STANDARD.decode(audio_response.audio_content)?,
-        ),
-        Some(reqwest::header::HeaderValue::from_static(
-            audio_encoding.content_type(),
-        )),
-    ))
-}
-
-static VOICES: tokio::sync::OnceCell<Vec<GoogleVoice>> = tokio::sync::OnceCell::const_new();
-async fn get_voices_(state: &RwLock<State>) -> Result<Vec<GoogleVoice>> {
-    #[derive(serde::Deserialize)]
-    struct VoiceResponse {
-        voices: Vec<GoogleVoice>,
-    }
-
-    let jwt_token = refresh_jwt(state).await?;
-    let reqwest = state.read().await.reqwest.clone();
-
-    let resp: VoiceResponse = reqwest
-        .get(format!("{GOOGLE_API_BASE}v1/voices"))
-        .header("Authorization", format!("Bearer {jwt_token}"))
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
-
-    Ok(resp.voices)
-}
-
-pub async fn check_voice(state: &RwLock<State>, voice: &str) -> Result<bool> {
-    Ok(get_voices(state).await?.iter().any(|s| s.as_str() == voice))
-}
-
-pub async fn get_raw_voices(state: &RwLock<State>) -> Result<&'static Vec<GoogleVoice>> {
-    VOICES.get_or_try_init(|| get_voices_(state)).await
-}
-
-pub async fn get_voices(state: &RwLock<State>) -> Result<Vec<String>> {
-    Ok(VOICES
-        .get_or_try_init(|| get_voices_(state))
-        .await?
-        .iter()
-        .filter_map(|gvoice| {
-            gvoice
-                .name
-                .splitn(3, '-')
-                .nth(2)?
-                .split_once('-')
-                .filter(|(mode, _)| *mode == "Standard")
-                .map(|(_, variant)| {
-                    let [mut language] = gvoice.languageCodes.clone();
-                    language.push(' ');
-                    language.push_str(variant);
-                    language
-                })
-        })
-        .collect())
+    Ok(JWTToken {
+        token: jwt_token,
+        expire_time: new_expire_time,
+    })
 }

--- a/src/modes/gtts.rs
+++ b/src/modes/gtts.rs
@@ -1,21 +1,167 @@
 use std::{
+    fmt::Display,
     sync::{Arc, OnceLock, atomic::AtomicBool},
     time::Duration,
 };
 
 use aformat::ToArrayString;
+use async_trait::async_trait;
+use axum::{
+    http::HeaderValue,
+    response::{IntoResponse, Response},
+};
+use bytes::Bytes;
 use ipgen::IpNetwork;
 use itertools::Itertools;
 use rand::RngExt as _;
+use serde_json::to_value;
 use tokio::sync::RwLock;
 
-use crate::{DeadlineMonitor, Result};
+use crate::{DeadlineMonitor, Result, TTSEngine, TTSParams, TTSVoices};
 
 #[derive(Clone)]
 pub struct State {
-    ip: std::net::IpAddr,
+    ip_client: Arc<RwLock<IpClient>>,
     ip_block: Option<IpNetwork>,
-    pub http: reqwest::Client,
+    hit_any_deadline: Arc<AtomicBool>,
+}
+
+struct IpClient {
+    client: reqwest::Client,
+    ip: std::net::IpAddr,
+}
+impl IpClient {
+    fn new_ip(&mut self, ip: std::net::IpAddr) -> Result<()> {
+        self.client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .local_address(Some(ip))
+            .build()?;
+        self.ip = ip;
+        Ok(())
+    }
+    async fn get(&self, text: &str, lang: &str) -> Result<CheckResult> {
+        let mut url = get_base_url();
+        url.query_pairs_mut()
+            .append_pair("tl", lang)
+            .append_pair("q", text)
+            .append_pair("textlen", &text.len().to_arraystring())
+            .finish();
+        is_block(self.client.get(url).send().await).await
+    }
+
+    pub async fn get_random_ipv6(&mut self, ip_block: Option<IpNetwork>) -> Result<()> {
+        let Some(ip_block) = ip_block else {
+            self.new_ip("0.0.0.0".parse()?)?;
+            return Ok(());
+        };
+
+        let mut attempts = 1;
+        loop {
+            let name: String = rand::rng()
+                .sample_iter::<char, _>(rand::distr::StandardUniform)
+                .take(16)
+                .collect();
+
+            tracing::debug!("Generated random name: {:?}", name.as_bytes());
+            let ip = ipgen::ip(&name, ip_block).unwrap();
+
+            self.new_ip(ip);
+
+            let check_result = self.get("Hello", "en").await?;
+            if let CheckResult::Ok(..) = check_result {
+                tracing::warn!("Generated random IP: {ip}");
+                break;
+            }
+            tracing::warn!(
+                "Failed to generate a new IP on attempt {attempts} with a {check_result}"
+            );
+
+            attempts += 1;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TTSEngine for State {
+    async fn check_params(&self, params: TTSParams<'_>) -> Option<Response> {
+        if params.speaking_rate < 0. {
+            Some("Speaking rate cannot be negative".into_response())
+        } else if !self
+            .get_voices()
+            .await
+            .ok()?
+            .nice
+            .iter()
+            .any(|s| s.as_str() == params.voice)
+        {
+            Some(format!("Voice {} is not known", params.voice).into_response())
+        } else {
+            None
+        }
+    }
+    fn check_length(&self, audio: &[u8], max_length: u64) -> bool {
+        use bytes::Buf;
+        mp3_duration::from_read(&mut audio.reader()).map_or(true, |d| d.as_secs() < max_length)
+    }
+    async fn speak(
+        &self,
+        text: &str,
+        params: TTSParams<'_>,
+        preferred_format: Option<&str>,
+    ) -> Result<(Bytes, Option<HeaderValue>)> {
+        let _guard = DeadlineMonitor::new(
+            Duration::from_secs(3),
+            self.hit_any_deadline.clone(),
+            |took| {
+                tracing::warn!("Fetching gTTS audio took {} millis!", took.as_millis());
+            },
+        );
+
+        let mut content_type = None;
+        let mut audio = Vec::new();
+
+        let mut client = self.ip_client.read().await;
+        let chunks: Vec<String> = text
+            .chars()
+            .chunks(200)
+            .into_iter()
+            .map(Iterator::collect)
+            .collect();
+        for chunk in chunks {
+            loop {
+                let result = client.get(&chunk, params.voice).await?;
+
+                if let CheckResult::Ok(content_type_, audio_chunk) = result {
+                    if let Some(content_type_) = content_type_ {
+                        content_type = Some(content_type_);
+                    }
+
+                    break audio.extend(audio_chunk);
+                }
+                {
+                    drop(client);
+                    let mut rw_client = self.ip_client.write().await;
+                    tracing::warn!("IP {} has been blocked!", rw_client.ip);
+                    rw_client.get_random_ipv6(self.ip_block).await?;
+                    client = self.ip_client.read().await;
+                }
+            }
+        }
+
+        Ok((bytes::Bytes::from(audio), content_type))
+    }
+    async fn get_voices(&self) -> Result<TTSVoices> {
+        let raw: std::collections::BTreeMap<String, String> =
+            serde_json::from_str(include_str!("data/voices-gtts.json"))?;
+        Ok(TTSVoices {
+            raw: to_value(raw.clone())?,
+            nice: raw.into_keys().collect(),
+        })
+    }
+    fn get_defaults(&self) -> TTSParams<'static> {
+        todo!()
+    }
 }
 
 fn get_base_url() -> reqwest::Url {
@@ -30,65 +176,31 @@ fn get_base_url() -> reqwest::Url {
         .clone()
 }
 
-fn parse_url(text: &str, lang: &str) -> reqwest::Url {
-    let mut url = get_base_url();
-    url.query_pairs_mut()
-        .append_pair("tl", lang)
-        .append_pair("q", text)
-        .append_pair("textlen", &text.len().to_arraystring())
-        .finish();
-    url
-}
-
-pub async fn get_random_ipv6(ip_block: Option<IpNetwork>) -> Result<State> {
-    let Some(ip_block) = ip_block else {
-        return Ok(State {
-            ip_block: None,
-            ip: "0.0.0.0".parse()?,
-            http: reqwest::Client::new(),
-        });
-    };
-
-    let mut attempts = 1;
-    loop {
-        let name: String = rand::rng()
-            .sample_iter::<char, _>(rand::distr::StandardUniform)
-            .take(16)
-            .collect();
-
-        tracing::debug!("Generated random name: {:?}", name.as_bytes());
-        let ip = ipgen::ip(&name, ip_block).unwrap();
-
-        let http = reqwest::Client::builder()
-            .connect_timeout(std::time::Duration::from_secs(5))
-            .local_address(Some(ip))
-            .build()?;
-
-        let check_request = http.get(parse_url("Hello", "en")).send().await;
-        let fail_reason = match is_block(check_request).await? {
-            CheckResult::Ok(..) => {
-                tracing::warn!("Generated random IP: {ip}");
-                break Ok(State {
-                    ip,
-                    http,
-                    ip_block: Some(ip_block),
-                });
-            }
-            CheckResult::NormalBlock => "429 block",
-            CheckResult::TimeoutBlock => "timeout block",
-            CheckResult::HostUnreachable => "unreachable error",
-        };
-
-        tracing::warn!("Failed to generate a new IP on attempt {attempts} with a {fail_reason}");
-        attempts += 1;
-    }
-}
-
 enum CheckResult {
     Ok(Option<reqwest::header::HeaderValue>, bytes::Bytes),
     NormalBlock,
     TimeoutBlock,
     HostUnreachable,
+}
+impl Display for CheckResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CheckResult::NormalBlock => write!(f, "429 block"),
+            CheckResult::TimeoutBlock => write!(f, "timeout block"),
+            CheckResult::HostUnreachable => write!(f, "unreachable error"),
+            CheckResult::Ok(Some(header_value), bytes) => {
+                write!(
+                    f,
+                    "{} bytes of {}",
+                    bytes.len(),
+                    header_value.to_str().unwrap_or("unknown")
+                )
+            }
+            CheckResult::Ok(None, bytes) => {
+                write!(f, "{} bytes of unknown", bytes.len())
+            }
+        }
+    }
 }
 
 fn is_host_unreachable(err: &reqwest::Error) -> bool {
@@ -120,62 +232,4 @@ async fn is_block(resp: reqwest::Result<reqwest::Response>) -> Result<CheckResul
             }
         }
     }
-}
-
-pub async fn get_tts(
-    state: &RwLock<State>,
-    text: &str,
-    voice: &str,
-    hit_any_deadline: Arc<AtomicBool>,
-) -> Result<(bytes::Bytes, Option<reqwest::header::HeaderValue>)> {
-    let _guard = DeadlineMonitor::new(Duration::from_secs(3), hit_any_deadline, |took| {
-        tracing::warn!("Fetching gTTS audio took {} millis!", took.as_millis());
-    });
-
-    let mut content_type = None;
-    let mut audio = Vec::new();
-
-    let chunks: Vec<String> = text
-        .chars()
-        .chunks(200)
-        .into_iter()
-        .map(Iterator::collect)
-        .collect();
-    for chunk in chunks {
-        loop {
-            let (ip, result) = {
-                let State { ip, http, .. } = state.read().await.clone();
-                (ip, http.get(parse_url(&chunk, voice)).send().await)
-            };
-
-            if let CheckResult::Ok(content_type_, audio_chunk) = is_block(result).await? {
-                if let Some(content_type_) = content_type_ {
-                    content_type = Some(content_type_);
-                }
-
-                break audio.extend(audio_chunk);
-            }
-
-            // Generate a new client, with an new IP, and try again
-            let mut state = state.write().await;
-            if state.ip == ip {
-                tracing::warn!("IP {ip} has been blocked!");
-                *state = get_random_ipv6(state.ip_block).await?;
-            }
-        }
-    }
-
-    Ok((bytes::Bytes::from(audio), content_type))
-}
-
-pub fn check_voice(voice: &str) -> bool {
-    get_voices().iter().any(|s| s.as_str() == voice)
-}
-
-pub fn get_voices() -> Vec<String> {
-    get_raw_voices().into_keys().collect()
-}
-
-pub fn get_raw_voices() -> std::collections::BTreeMap<String, String> {
-    serde_json::from_str(include_str!("data/voices-gtts.json")).unwrap()
 }


### PR DESCRIPTION
### Motivation

The current statically dispatched nature of TTSMode calling static functions of a module complicates a few things:
- state handling is more annoying and messy, needing to be done primarily in code which touches all TTS providers/engines
- making TTS providers/engines optional in a clean way is harder, due to the above
- adding new TTS providers/engines doesn't have a clearly limited scope, due to how much of the logic happens mixed together with all other TTS providers/engines

### Solution

Introduce a Trait for TTSEngine, which serves as the only interface through which individual engines/providers are communicated with after startup. This allows storing TTSEngines in a dynamic collection, in this PR a `HashMap<String, Box<dyn TTSEngine>>`.

This trait incorporates some of the checking logic from TTSMode besides what was already in the individual modules. This decouples TTSEngines further from the web backend code.

### Progress

So far i've designed and defined the trait, and ported gtts, gcloud and espeak over to it. Polly is still missing, as is the major effort of cleaning up main.rs to use this new trait.

I'm mainly sharing this at this stage to reach out to @GnomedDev and see if this is even something thats welcome. I'll admit i started only wanting to make gcloud optional and kinda got carried away once i looked at the code some more.